### PR TITLE
Implement backup utils and tests

### DIFF
--- a/agent/backup.py
+++ b/agent/backup.py
@@ -1,18 +1,76 @@
 """Backup utilities for Recon Agent."""
 
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta
 from pathlib import Path
 import shutil
+from typing import Iterable
+
+__all__ = ["create_backup", "prune_backups"]
 
 
-def create_backup(source: str, target_dir: str) -> Path:
-    """Create a zip archive of the source directory.
+def create_backup(source: str | os.PathLike, target_dir: str | os.PathLike,
+                  *, retention_days: int | None = None) -> Path:
+    """Create a ZIP archive from ``source`` inside ``target_dir``.
 
-    This is a placeholder implementation used during early development.
+    Parameters
+    ----------
+    source:
+        Directory to archive.
+    target_dir:
+        Directory where the archive will be created.
+    retention_days:
+        If provided, ``prune_backups`` will be called after creation using this
+        value.
+
+    Returns
+    -------
+    :class:`pathlib.Path`
+        Path to the created archive.
     """
-    # TODO: add error handling and retention policy
+
     src = Path(source)
+    if not src.is_dir():
+        raise FileNotFoundError(f"Backup source not found: {src}")
+
     dst = Path(target_dir)
     dst.mkdir(parents=True, exist_ok=True)
-    archive = dst / f"{src.name}.zip"
-    shutil.make_archive(str(archive.with_suffix("")), "zip", source)
+
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    archive = dst / f"backup_{src.name}_{timestamp}.zip"
+
+    shutil.make_archive(str(archive.with_suffix("")), "zip", str(src))
+
+    if retention_days is not None:
+        prune_backups(dst, retention_days)
+
     return archive
+
+
+def prune_backups(directory: str | os.PathLike, retention_days: int) -> None:
+    """Remove backup archives older than ``retention_days``.
+
+    Parameters
+    ----------
+    directory:
+        The directory containing backup archives.
+    retention_days:
+        Age threshold in days. Files older than this will be deleted.
+    """
+
+    cutoff = datetime.utcnow() - timedelta(days=retention_days)
+    dir_path = Path(directory)
+
+    for path in _iter_archives(dir_path):
+        if path.stat().st_mtime < cutoff.timestamp():
+            path.unlink(missing_ok=True)
+
+
+def _iter_archives(directory: Path) -> Iterable[Path]:
+    """Yield ``.zip`` files within ``directory``."""
+
+    for child in directory.iterdir():
+        if child.suffix == ".zip" and child.is_file():
+            yield child

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,48 @@
+import os
+from datetime import datetime, timedelta
+import zipfile
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agent.backup import create_backup, prune_backups
+
+
+def test_create_backup(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "file.txt").write_text("data")
+
+    backup_dir = tmp_path / "backups"
+    path = create_backup(src, backup_dir)
+
+    assert path.exists()
+    assert path.parent == backup_dir
+    with zipfile.ZipFile(path) as zf:
+        assert "file.txt" in zf.namelist()
+
+
+def test_create_backup_missing_source(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        create_backup(tmp_path / "missing", tmp_path)
+
+
+def test_prune_backups(tmp_path):
+    backup_dir = tmp_path / "backups"
+    backup_dir.mkdir()
+
+    old_file = backup_dir / "old.zip"
+    old_file.write_text("old")
+    # set modification time to 2 days ago
+    old_time = (datetime.utcnow() - timedelta(days=2)).timestamp()
+    os.utime(old_file, (old_time, old_time))
+
+    new_file = backup_dir / "new.zip"
+    new_file.write_text("new")
+
+    prune_backups(backup_dir, retention_days=1)
+
+    assert not old_file.exists()
+    assert new_file.exists()


### PR DESCRIPTION
## Summary
- implement backup creation/retention logic
- add prune_old_backups helper
- add unit tests for backup utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854d64e18808332a8a27ab4e11175c4