### PR TITLE
Refine roadmap Phase 2 tasks

### DIFF
--- a/docs/dev/roadmap.md
+++ b/docs/dev/roadmap.md
@@ -44,9 +44,12 @@ The project will be built in clear phases, starting with an MVP designed for qui
 - [x] Populate placeholder modules with TODOs or minimal code
 - [ ] `backup.py`: performs file zips and local backups
 - [ ] `monitor.py`: detects server status, ports, resources
+- [ ] Implement HTTP server and command endpoints
 - [ ] Load and validate `config.yaml`
+- [ ] Schedule automated backups
 - [ ] Discord webhook alert system
-- [ ] Add changelog and internal logging
+- [ ] Send heartbeat messages to the bot
+- [ ] Add changelog entry and internal logging with log rotation
 - [ ] Implement auth token validation and TLS proxy enforcement
 - [ ] Document token generation, rotation strategy, and security notes
 


### PR DESCRIPTION
## Summary
- expand Phase 2 agent tasks in docs/dev/roadmap.md
  - add HTTP server implementation
  - include scheduler and heartbeat work
  - clarify changelog/logging requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68555b9b65848332b2bd8225873fd3ad